### PR TITLE
Fixed wrong image resize due to the use of backingScaleFactor instead…

### DIFF
--- a/Retini/ResizeModel.m
+++ b/Retini/ResizeModel.m
@@ -88,40 +88,40 @@
 
 - (void)resize3x:(NSString *)fileName
 {
-	NSImage *original = [[NSImage alloc] initWithContentsOfFile:fileName];
-	
-	CGFloat screenScale = [[NSScreen mainScreen] backingScaleFactor];
-	float width = (original.size.width * 2) / screenScale;
-	float height = (original.size.height * 2) / screenScale;
-	
-	NSImage *newImg2x = [self imageResize:[original copy] newSize:NSMakeSize(width, height)];
-	
-	if([self saveImage:newImg2x toPath:[fileName stringByReplacingOccurrencesOfString:@"@3x" withString:@"@2x"]]){
-		NSImage *newImg = [self imageResize:[original copy] newSize:NSMakeSize(original.size.width / screenScale, original.size.height / screenScale)];
-		
-		[self saveImage:newImg toPath:[fileName stringByReplacingOccurrencesOfString:@"@3x" withString:@""]];
-	}
-	
-	if([[NSUserDefaults standardUserDefaults] integerForKey:@"pngOut"] == 1){
-		[self crushPng:fileName];
-	}
+    NSImage *original = [[NSImage alloc] initWithContentsOfFile:fileName];
+    if(original.representations.count > 0){
+        float width = original.representations[0].pixelsWide;
+        float height = original.representations[0].pixelsHigh;
+        
+        NSImage *newImg2x = [self imageResize:[original copy] newSize:NSMakeSize(2*width/3, 2*height/3)];
+        
+        if([self saveImage:newImg2x toPath:[fileName stringByReplacingOccurrencesOfString:@"@3x" withString:@"@2x"]]){
+            NSImage *newImg = [self imageResize:[original copy] newSize:NSMakeSize(width/3, height/3)];
+            
+            [self saveImage:newImg toPath:[fileName stringByReplacingOccurrencesOfString:@"@3x" withString:@""]];
+        }
+        
+        if([[NSUserDefaults standardUserDefaults] integerForKey:@"pngOut"] == 1){
+            [self crushPng:fileName];
+        }
+    }
 }
 
 - (void)resize2x:(NSString *)fileName
 {
-	NSImage *original = [[NSImage alloc] initWithContentsOfFile:fileName];
-	
-	CGFloat screenScale = [[NSScreen mainScreen] backingScaleFactor];
-	float width = original.size.width / screenScale;
-	float height = original.size.height / screenScale;
-	
-	NSImage *newImg = [self imageResize:original newSize:NSMakeSize(width, height)];
-	
-	[self saveImage:newImg toPath:[fileName stringByReplacingOccurrencesOfString:@"@2x" withString:@""]];
-	
-	if([[NSUserDefaults standardUserDefaults] integerForKey:@"pngOut"] == 1){
-		[self crushPng:fileName];
-	}
+    NSImage *original = [[NSImage alloc] initWithContentsOfFile:fileName];
+    if(original.representations.count > 0){
+        float width = original.representations[0].pixelsWide;
+        float height = original.representations[0].pixelsHigh;
+        
+        NSImage *newImg = [self imageResize:original newSize:NSMakeSize(width/2, height/2)];
+        
+        [self saveImage:newImg toPath:[fileName stringByReplacingOccurrencesOfString:@"@2x" withString:@""]];
+        
+        if([[NSUserDefaults standardUserDefaults] integerForKey:@"pngOut"] == 1){
+            [self crushPng:fileName];
+        }
+    }
 }
 
 - (NSImage *)imageResize:(NSImage *)anImage newSize:(NSSize)newSize


### PR DESCRIPTION
… of using the real image size in pixels

Hi!

If had an issue when trying to downscale images.
For example, an @3x image of 180x180 px gives me:
@2x => 90x90px
@1x => 45x45px

The expected results are
@2x => 120x120px
@1x => 60x60px

The issue is due to the use of NSScreen backingScaleFactor to calculate the real size of the image. I have a screen with a backingScaleFactor of 1.

I corrected the code so that we don't calculate the real image size based on the screen scale factor but by using the real image data.
